### PR TITLE
Add initial docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM centos:centos7
+RUN yum install -y make nc mariadb php php-mysql

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.DEFAULT_GOAL := help
+.PHONY = help init
+
+DB_NAME = treestories
+DB_HOST = db
+SCHEMA_DUMP = "./treestories.sql"
+
+
+help:
+		@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST)\
+		| sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+
+load_db:  ## Create DB schema
+		mysql -h$(DB_HOST) -uroot $(DB_NAME) < $(SCHEMA_DUMP)
+
+test:  ## Run tests
+		@echo "Why aren't there any tests?"
+

--- a/README.md
+++ b/README.md
@@ -9,10 +9,22 @@ Edit the paths shown in the file and restart the service.
     vi /etc/httpd/vhost.d/treestories.conf
     service httpd restart
 
-You will also need to copy the database schema, and will have to get the tree data
-from the server.
-
+You will also need to load the database schema.
     mysqld treestories < treestories.sql
+
+## DOCKER installation and serving
+A DockerFile and docker-compose file are provided. To build a php
+webserver container and a db container run:
+
+    docker-compose up
+
+This will build and launch the containers, load the db schema, and run a
+development PHP server on port 8000 (localhost:8000)
+
+## Tree Data
+You will need to copy the GEOJson files from the server in order to
+serve the tree data.
+
     mkdir data && cd data
     wget -r --no-parent https://climatecope.research.pdx.edu/cs/data/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    volumes:
+      - .:/code
+    working_dir: /code
+    command: ./entrypoint.sh
+
+  db:
+    image: orchardup/mysql
+    environment:
+      MYSQL_DATABASE: treestories

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# wait for mysql to be ready
+while ! nc db 3306;
+    do
+        sleep 1;
+    done;
+make load_db
+php -S 0.0.0.0:8000 -t /code


### PR DESCRIPTION
- You can now run docker-compose up to build and run
a PHP webserver and DB container available at
localhost:8000.
- README updated to include Docker info.